### PR TITLE
Fix xmpp invite bug.

### DIFF
--- a/lib/multi-user-chat.js
+++ b/lib/multi-user-chat.js
@@ -48,7 +48,7 @@ MultiUserChat.prototype._events = {
 MultiUserChat.prototype.registerSet = function(data, callback) {
     this.register(data, callback, 'set')
 }
-    
+
 MultiUserChat.prototype.registerGet = function(data, callback) {
     this.register(data, callback, 'get')
 }
@@ -84,7 +84,7 @@ MultiUserChat.prototype.handleMessage = function(stanza) {
 
     var isPrivate = false
     if ('chat' === stanza.attrs.type) isPrivate = true
-    
+
     var message = {
         room:    stanza.attrs.from.split('/')[0],
         nick:    stanza.attrs.from.split('/')[1],
@@ -115,7 +115,7 @@ MultiUserChat.prototype._handleRoomStatusUpdate = function(stanza) {
 }
 
 MultiUserChat.prototype._handleInvite = function(stanza) {
-    var data = { room: stanza.attrs.to }
+    var data = { room: stanza.attrs.from }
     var invite = stanza.getChild('x').getChild('invite')
     data.from = this._getJid(invite.attrs.from)
     var reason, password
@@ -169,7 +169,7 @@ MultiUserChat.prototype.handlePresence = function(stanza) {
             presence.jid = this._getJid(item.attrs.jid)
         if (item.attrs.nick)
             presence.nick = item.attrs.nick
-        
+
     }
     var statusUpdates = stanza.getChild('x').getChildren('status')
     if (statusUpdates.length > 0) {
@@ -386,7 +386,7 @@ MultiUserChat.prototype.register = function(data, callback, type) {
         var title, instructions, registered, nick
         var query = stanza.getChild('query')
         var data = {}
- 
+
         if (!!(registered = query.getChild('registered'))) {
             data.registered = true
             if (!!(nick = query.getChild('username')))

--- a/test/lib/multi-user-chat.invite.js
+++ b/test/lib/multi-user-chat.invite.js
@@ -23,7 +23,7 @@ describe('Can invite a user to a MUC room', function() {
         muc = new MultiUserChat()
         muc.init(manager)
     })
-    
+
     describe('Can send invites', function() {
 
         it('Returns error if \'room\' key not provided', function(done) {
@@ -40,7 +40,7 @@ describe('Can invite a user to a MUC room', function() {
             })
             socket.emit('xmpp.muc.invite', {})
         })
-    
+
         it('Returns error if \'to\' key not provided', function(done) {
             xmpp.once('stanza', function() {
                 done('Unexpected outgoing stanza')
@@ -56,7 +56,7 @@ describe('Can invite a user to a MUC room', function() {
             var request = { room: 'fire@coven@witches.lit' }
             socket.emit('xmpp.muc.invite', request)
         })
-    
+
         it('Sends the expected stanza', function(done) {
             var request = {
                 room: 'fire@coven.witches.lit',
@@ -66,7 +66,7 @@ describe('Can invite a user to a MUC room', function() {
                 stanza.is('message').should.be.true
                 stanza.attrs.to.should.equal(request.room)
                 stanza.attrs.id.should.exist
-                
+
                 var invite = stanza.getChild('x', muc.NS_USER)
                     .getChild('invite')
                 invite.should.exist
@@ -75,7 +75,7 @@ describe('Can invite a user to a MUC room', function() {
             })
             socket.emit('xmpp.muc.invite', request)
         })
-        
+
         it('Sends expected stanza with reason', function(done) {
             var request = {
                 room: 'fire@coven.witches.lit',
@@ -86,28 +86,28 @@ describe('Can invite a user to a MUC room', function() {
                 stanza.is('message').should.be.true
                 stanza.attrs.to.should.equal(request.room)
                 stanza.attrs.id.should.exist
-                
+
                 stanza.getChild('x', muc.NS_USER)
                     .getChild('invite')
                     .getChildText('reason')
                     .should.equal(request.reason)
-    
+
                 done()
             })
             socket.emit('xmpp.muc.invite', request)
         })
-        
+
     })
-    
+
     describe('Handles invites', function() {
-        
+
       it('Handles invites', function() {
           muc.handles(helper.getStanza('invite')).should.be.true
       })
-          
+
       it('Sends event to user', function(done) {
           socket.once('xmpp.muc.invite', function(data) {
-              data.room.should.equal('fire@coven.witches.lit')
+            data.room.should.equal('room@muc.coven.witches.lit')
               data.from.should.eql({
                   domain: 'witches.lit',
                   user: 'witch1'
@@ -116,7 +116,7 @@ describe('Can invite a user to a MUC room', function() {
           })
           muc.handle(helper.getStanza('invite')).should.be.true
       })
-      
+
       it('Sends event to user with reason & password', function(done) {
           socket.once('xmpp.muc.invite', function(data) {
               data.reason.should.equal('Doth one wish to be King?')
@@ -126,7 +126,7 @@ describe('Can invite a user to a MUC room', function() {
           muc.handle(helper.getStanza('invite-with-reason-and-password'))
               .should.be.true
       })
-      
+
     })
 
 })

--- a/test/resources/invite
+++ b/test/resources/invite
@@ -1,4 +1,5 @@
 <message
+    from= "room@muc.coven.witches.lit"
     id="invite:1"
     to="fire@coven.witches.lit">
   <x xmlns="http://jabber.org/protocol/muc#user">


### PR DESCRIPTION
We use the `xmpp-ftw-muc`  met issue, I found the error. 

I think the reveived message should be like this

Details in XEP-0045

``` XML
<message
    from='coven@chat.shakespeare.lit'
    id='nzd143v8'
    to='hecate@shakespeare.lit'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <invite from='crone1@shakespeare.lit/desktop'>
      <reason>
        Hey Hecate, this is the place for all good witches!
      </reason>
    </invite>
    <password>cauldronburn</password>
  </x>
</message>
```

PLZ check , and merge.
