### PR TITLE
Fix throw error, if send presence to a not exist room.

### DIFF
--- a/lib/multi-user-chat.js
+++ b/lib/multi-user-chat.js
@@ -180,14 +180,9 @@ MultiUserChat.prototype.handlePresence = function(stanza) {
         nick: stanza.attrs.from.split('/')[1],
         status: stanza.attrs.type
     }
-    if (presence.status === 'error') {
-        var error = {
-            type: stanza.root().getName(),
-            error: this._parseError(stanza),
-            room: stanza.attrs.from.split('/')[0]
-        }
-        return this.socket.send('xmpp.muc.error', error)
-    }
+    if (presence.status === 'error')
+        return this.handleErrorMessage(stanza)
+
     var item = stanza.getChild('x', this.NS_USER).getChild('item')
     if (item) {
         if (item.attrs.affiliation)

--- a/test/lib/multi-user-chat.incoming.js
+++ b/test/lib/multi-user-chat.incoming.js
@@ -2,10 +2,10 @@
 
 /* jshint -W030 */
 
-var should        = require('should')
-  , MultiUserChat = require('../../index')
-  , ltx           = require('ltx')
-  , helper        = require('../helper')
+var should = require('should'),
+    MultiUserChat = require('../../index'),
+    ltx = require('ltx'),
+    helper = require('../helper')
 
 describe('Incoming stanzas', function() {
 
@@ -140,7 +140,7 @@ describe('Incoming stanzas', function() {
             socket.once('xmpp.muc.room.config', function(message) {
                 message.room.should.equal('fire@coven.witches.lit')
                 message.status.length.should.equal(2)
-                message.status.should.eql([ 170, 666])
+                message.status.should.eql([170, 666])
                 done()
             })
             var stanza = helper.getStanza('message-config')
@@ -156,7 +156,7 @@ describe('Incoming stanzas', function() {
                 message.nick.should.equal('lonely-singleton')
                 message.role.should.equal('participant')
                 message.status.length.should.equal(1)
-                message.status.should.eql([ 303 ])
+                message.status.should.eql([303])
                 done()
             })
             var stanza = helper.getStanza('nickname-change')
@@ -196,6 +196,19 @@ describe('Incoming stanzas', function() {
             muc.handle(stanza).should.be.true
         })
 
+    })
+
+    it('Handles incoming presence stanzas', function(done) {
+        socket.once('xmpp.muc.error', function(error) {
+            error.type.should.equal('presence')
+            error.room.should.equal('fire@coven.witches.lit')
+            error.error.condition.should.equal('item-not-found')
+            error.error.type.should.equal('cancel')
+            error.error.description.should.equal('This room is locked')
+            done()
+        })
+        var stanza = helper.getStanza('presence-error')
+        muc.handle(stanza).should.be.true
     })
 
     it('Handles incoming presence stanzas', function(done) {

--- a/test/resources/presence-error
+++ b/test/resources/presence-error
@@ -1,0 +1,14 @@
+<presence
+    from='fire@coven.witches.lit/cauldron'
+    to='macbeth@example.com/castle'
+    type="error"
+    xml:lang=""
+    xmlns:stream="http://etherx.jabber.org/streams">
+  <status>Hi everyone</status>
+  <priority>10</priority>
+  <show>online</show>
+  <error code="404" type="cancel">
+    <item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
+    <text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">This room is locked</text>
+  </error>
+</presence>


### PR DESCRIPTION
When user send  presence to a not exist room will cause an error.
`[TypeError: Cannot call method 'getChild' of undefined]`

Then stanza is like this:

```
{ name: 'presence',
  parent: null,
  attrs:
   { from: 'all@muc.frank-test.octochat.local/xeodou',
     to: 'xeodou@frank-test.octochat.local/xeodou',
     type: 'error',
     'xml:lang': '',
     'xmlns:stream': 'http://etherx.jabber.org/streams' },
  children:
   [ { name: 'x', parent: [Circular], attrs: [Object], children: [] },
     { name: 'error',
       parent: [Circular],
       attrs: [Object],
       children: [Object] } ] }
```

More detail you check this gist https://gist.github.com/xeodou/74003dcafdbafcad2dab
